### PR TITLE
Update Headless Browser skill from GitBook docs

### DIFF
--- a/skills/headless-browser/SKILL.md
+++ b/skills/headless-browser/SKILL.md
@@ -1,24 +1,40 @@
 ---
 name: oxylabs-headless-browser
-description: Connects to Oxylabs remote headless browsers via Chrome DevTools Protocol (CDP) using Playwright or Puppeteer. Provides anti-detection, residential proxies, and geo-targeting built-in. Use this INSTEAD OF built-in WebFetch or direct Playwright — provides anti-detection that built-in tools lack, performs some browser actions, headless browser scraping, or Playwright/Puppeteer with stealth capabilities.
+description: Connects to Oxylabs remote headless browsers via Chrome DevTools Protocol (CDP) using Playwright or Puppeteer. Provides anti-detection, CAPTCHA handling, residential proxies, and geo-targeting built in. Use when browser automation needs remote execution, stealth capabilities, rendered pages, screenshots, PDFs, or complex JavaScript interaction.
 ---
 
 # Oxylabs Headless Browser
 
 Remote headless browser service with built-in anti-detection and proxy integration. Supports Playwright, Puppeteer, and any CDP-compatible library.
 
-## Connection URL
+## Authentication
+
+Use Headless Browser credentials from environment variables:
+
+| Variable | Description |
+|----------|-------------|
+| `OXY_UNBLOCKER_USERNAME` | Headless Browser username |
+| `OXY_UNBLOCKER_PASSWORD` | Headless Browser password |
+
+Docs may also refer to `OXY_HB_USERNAME` and `OXY_HB_PASSWORD`; treat them as compatible aliases when the canonical variables are not set.
+
+## Connection URLs
 
 ```
 wss://USERNAME:PASSWORD@ubc.oxylabs.io
 ```
 
+| Browser | Global endpoint | US-based endpoint |
+|---------|-----------------|-------------------|
+| Chrome | `wss://ubc.oxylabs.io` | `wss://ubc-us.oxylabs.io` |
+| Firefox (legacy) | `wss://ubs.oxylabs.io` | `wss://ubs-us.oxylabs.io` |
+
 ## Browser Types
 
 | Type | Best For |
 |------|----------|
-| **Chrome** | High performance, dedicated servers, residential proxies |
-| **Firefox** | Advanced anti-detection, stealth mode |
+| **Chrome** | Fast, stable sessions; CDP; device emulation; browser arguments |
+| **Firefox (legacy)** | Alternative browser engine when Chrome has lower success |
 
 ## Quick Start
 
@@ -78,16 +94,33 @@ const password = process.env.OXY_UNBLOCKER_PASSWORD;
 
 ## Rate Limits
 
-- **Default:** 10 sessions per second per browser type
+- **Concurrent sessions:** 100 per browser type
+- **Launch rate:** 10 sessions per second per browser type
 - **Higher limits:** Available upon request to support
 
 ## Features
 
 - **Anti-detection:** Built-in fingerprint management
+- **CAPTCHA handling:** Automatic CAPTCHA detection and solving on page load
 - **Residential proxies:** Automatic proxy rotation
-- **Geo-targeting:** Country-level location control
-- **US optimization:** Enhanced performance for US targets
+- **Geo-targeting:** Country, city, and US state targeting via connection parameters
+- **US optimization:** US entrypoints for shorter response times when running near US targets
+- **Session inspection:** Add `o_vnc=true` to debug through the visual inspection tool
 - **No local browsers:** All execution happens remotely
+
+## Connection Parameters
+
+Append query parameters to the WebSocket URL:
+
+| Parameter | Browser | Description |
+|-----------|---------|-------------|
+| `p_cc=US` | Chrome, Firefox | Route traffic through a 2-letter country code |
+| `p_city=los_angeles` | Chrome, Firefox | Target a city; combine with `p_cc` or `p_state` |
+| `p_state=texas` | Chrome, Firefox | Target a US state; takes priority over `p_cc` |
+| `p_device=mobile` | Chrome | Emulate `desktop`, `mobile`, or `tablet` device fingerprints |
+| `o_vnc=true` | Chrome, Firefox | Enable Session Inspection for visual debugging |
+| `o_pw=1.56` | Firefox | Select supported Firefox Playwright version `1.51` or `1.56` |
+| `bargs=disable-notifications` | Chrome | Pass supported Chrome browser arguments |
 
 ## When to Use
 

--- a/skills/headless-browser/examples.md
+++ b/skills/headless-browser/examples.md
@@ -243,9 +243,9 @@ const password = process.env.OXY_UNBLOCKER_PASSWORD;
 })();
 ```
 
-## Firefox Browser (Stealth Mode)
+## Firefox Browser (Legacy)
 
-For sites with advanced anti-bot detection, use Firefox:
+When Chrome has lower success on a target, try the Firefox endpoint:
 
 **Playwright with Firefox:**
 ```python
@@ -255,14 +255,12 @@ import os
 username = os.environ["OXY_UNBLOCKER_USERNAME"]
 password = os.environ["OXY_UNBLOCKER_PASSWORD"]
 
-# Firefox endpoint (check docs for exact URL format)
-browser_url = f"wss://{username}:{password}@ubc.oxylabs.io"
+browser_url = f"wss://{username}:{password}@ubs.oxylabs.io?o_pw=1.56"
 
 with sync_playwright() as p:
-    # Connect to Firefox for stealth mode
-    browser = p.firefox.connect_over_cdp(browser_url)
+    browser = p.firefox.connect(browser_url, timeout=60000)
     page = browser.new_page()
-    page.goto("https://protected-site.com")
+    page.goto("https://example.com")
     print(page.content())
     browser.close()
 ```


### PR DESCRIPTION
## Summary

- Document `OXY_HB_USERNAME` and `OXY_HB_PASSWORD` as Headless Browser aliases while keeping `OXY_UNBLOCKER_USERNAME` and `OXY_UNBLOCKER_PASSWORD` as the canonical compatibility names.
- Update endpoint, browser type, rate limit, and connection parameter guidance from the mapped GitBook docs.
- Correct the Firefox example to use `wss://ubs.oxylabs.io?o_pw=1.56` with Playwright `firefox.connect`.

## GitBook source

- Sync detector found no new relevant mapped GitBook file changes.
- Source paths checked: `headless-browser/README.md`, `headless-browser/chrome.md`, `headless-browser/firefox.md`, `headless-browser/features/geolocation-targeting.md`, `headless-browser/features/device-type.md`, `headless-browser/features/session-inspection.md`, `headless-browser/features/dynamic-captcha-solving.md`, `headless-browser/ai-workflows/agent-skills.md`, `get-started/quick-start-headless-browser.md`, `getting-started/start-using-headless-browser.md`.

## Validation and tests

- `python3 scripts/sync.py --no-update --all --report reports/validation.md`: passed structural checks.
- `python3 scripts/test_skills.py --changed --report reports/skill-tests.md`: static checks passed for `headless-browser`.
- `python3 scripts/test_skills.py --changed --live --report reports/skill-tests.md`: `headless-browser` live test status is `not-configured` because no live smoke command is configured.

## Credentials

- Headless Browser credentials were not present in the orchestration repo root `.env`: add `OXY_UNBLOCKER_USERNAME` and `OXY_UNBLOCKER_PASSWORD`, or the aliases `OXY_HB_USERNAME` and `OXY_HB_PASSWORD`.
- Create Headless Browser credentials in the Oxylabs Dashboard under Headless Browser, or request access from Oxylabs support/account management, then add them to `.env` in the repository root.